### PR TITLE
Fix the CMake (Windows) versioning information.

### DIFF
--- a/recipe/0004-Fix-the-CMake-versioning-information.patch
+++ b/recipe/0004-Fix-the-CMake-versioning-information.patch
@@ -1,0 +1,45 @@
+From d0c5dff07553c4fa05d09f604ff7b7e0fc4c4f7c Mon Sep 17 00:00:00 2001
+From: Peter Williams <peter@newton.cx>
+Date: Wed, 5 Sep 2018 21:35:24 -0400
+Subject: [PATCH 2/2] Fix the CMake versioning information.
+
+First, the CMake build scripts have shared-object version that's simply
+inconsistent with the autotools-based build. Second, they were embedding the
+wrong version in the pkg-config file: it should by the Libtool version number
+rather than the package version number. Fun times.
+---
+ CMakeLists.txt | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5cf5efa..8d69aee 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -139,9 +139,14 @@ set(VERSION_PATCH "1")
+ #     Increment AGE. Set REVISION to 0
+ #   If the source code was changed, but there were no interface changes:
+ #     Increment REVISION.
+-set(LIBRARY_VERSION "6.16.0")
++set(LIBRARY_VERSION "6.16.1")
+ set(LIBRARY_SOVERSION "6")
+ 
++# The version in the pkg-config file should be "version_info" from
++# builds/unix/configure.raw, which is related to the above numbers. See
++# docs/VERSIONS.TXT.
++set(LIBTOOL_VERSION_INFO "22.1.16")
++
+ # These options mean "require x and complain if not found". They'll get
+ # optionally found anyway. Use `-DCMAKE_DISABLE_FIND_PACKAGE_x=TRUE` to disable
+ # searching for a packge entirely (x is the CMake package name, so "BZip2"
+@@ -437,7 +442,7 @@ if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+            FREETYPE2_PC_IN ${FREETYPE2_PC_IN})
+     string(REPLACE "%includedir%" "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}"
+            FREETYPE2_PC_IN ${FREETYPE2_PC_IN})
+-    string(REPLACE "%ft_version%" "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
++    string(REPLACE "%ft_version%" "${LIBTOOL_VERSION_INFO}"
+            FREETYPE2_PC_IN ${FREETYPE2_PC_IN})
+     string(REPLACE "%REQUIRES_PRIVATE%" "${PKG_CONFIG_REQUIRED_PRIVATE}"
+            FREETYPE2_PC_IN ${FREETYPE2_PC_IN})
+-- 
+2.17.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,10 @@ source:
     - 0001-Unbreak-CMake-Windows-installation.patch
     - 0002-Win-Specify-RUNTIME-destination-for-dll.patch
     - 0003-Install-the-pkg-config-file-on-Windows-too.patch
+    - 0004-Fix-the-CMake-versioning-information.patch
 
 build:
-  number: 3
+  number: 4
   run_exports:
     # has removed symbols at minor versions, but only very rarely.  Go with major.
     #    https://abi-laboratory.pro/tracker/timeline/freetype/


### PR DESCRIPTION
Discovered after working with freetype and pkg-config on Windows. First, the CMake build scripts have a shared-object version that's simply inconsistent with the autotools-based build. Second, the scripts were embedding the wrong version in the pkg-config file: it should be the Libtool version number rather than the package version number. Fun times. The file `docs/VERSIONS.TXT` logs some of the key info and helps show the relation between the Libtool version and the shlib version.