### PR TITLE
BLD: Update Windows build script

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -20,7 +20,7 @@ cmake %CMAKE_ARGS% -G"Ninja" ^
 if errorlevel 1 exit 1
 
 :: Build.
-ninja install
+cmake --build . --config Release
 if errorlevel 1 exit 1
 
 :: Test.
@@ -30,7 +30,7 @@ if not "%CONDA_BUILD_SKIP_TESTS%"=="1" (
 if errorlevel 1 exit 1
 
 :: Install.
-cmake --build . --config Release --target install
+cmake --install .
 if errorlevel 1 exit 1
 
 :: Move everything 1-level down.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,13 +11,11 @@ cmake %CMAKE_ARGS% -G"Ninja" ^
       -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%:/=\\" ^
       -DCMAKE_SYSTEM_PREFIX_PATH="%LIBRARY_PREFIX:/=\\%" ^
       -DBUILD_SHARED_LIBS:BOOL=true ^
-      -DFT_WITH_BZIP2=False ^
-      -DFT_WITH_HARFBUZZ=False ^
-      -DCMAKE_DISABLE_FIND_PACKAGE_BZip2=True ^
-      -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz=True ^
-      -DFT_WITH_ZLIB=True ^
-      -DFT_WITH_PNG=True ^
-      -DFT_WITH_BROTLI=False ^
+      -DFT_DISABLE_BZIP2=TRUE ^
+      -DFT_DISABLE_HARFBUZZ=TRUE ^
+      -DFT_DISABLE_ZLIB=FALSE ^
+      -DFT_DISABLE_PNG=FALSE ^
+      -DFT_DISABLE_BROTLI=TRUE ^
       "%SRC_DIR:/=\\%"
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 73819bbf34c84f18b89ebbd35107d3ae92c604ff7336cd09ff1452930c2dcb9c
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -21,7 +21,7 @@ requirements:
     - cmake                # [win]
     - make                 # [not win]
     - ninja                # [win]
-    - pkg-config           # [unix]
+    - pkg-config
     - libtool              # [unix]
   host:
     - libpng


### PR DESCRIPTION
When we weren't looking. The arguments for the CMakeLists changed.

Specifically, `DFT_WITH_HARFBUZZ -> NOT DFT_DISABLE_HARFBUZZ`. This resulted in us getting default values for all the options. Which may be the cause of the segmentation fault on Windows.

Also, I discovered that the test have moved, so none of the builds are running tests currently. Upstream now builds their tests using meson. I will open an issue to track this.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
