### PR TITLE
Add test for pkg-config metadata

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,16 +12,24 @@ jobs:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        build_workspace_dir: ~/miniforge3/conda-bld
+        store_build_artifacts: false
+        tools_install_dir: ~/miniforge3
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
+        build_workspace_dir: ~/miniforge3/conda-bld
+        store_build_artifacts: false
+        tools_install_dir: ~/miniforge3
   timeoutInMinutes: 360
   variables: {}
 
   steps:
   # TODO: Fast finish on azure pipelines?
   - script: |
+      export MINIFORGE_HOME=$(tools_install_dir)
+      export CONDA_BLD_PATH=$(build_workspace_dir)
       export CI=azure
       export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
       export remote_url=$(Build.Repository.Uri)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,13 +11,17 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
+        build_workspace_dir: D:\\bld\\
+        store_build_artifacts: false
+        tools_install_dir: D:\Miniforge
       win_arm64_:
         CONFIG: win_arm64_
         UPLOAD_PACKAGES: 'True'
+        build_workspace_dir: C:\\bld\\
+        store_build_artifacts: false
+        tools_install_dir: C:\Miniforge
   timeoutInMinutes: 360
   variables:
-    CONDA_BLD_PATH: D:\\bld\\
-    MINIFORGE_HOME: D:\Miniforge
     UPLOAD_TEMP: D:\\tmp
 
   steps:
@@ -26,8 +30,8 @@ jobs:
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:
-        MINIFORGE_HOME: $(MINIFORGE_HOME)
-        CONDA_BLD_PATH: $(CONDA_BLD_PATH)
+        MINIFORGE_HOME: $(tools_install_dir)
+        CONDA_BLD_PATH: $(build_workspace_dir)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma9
 freetype:
 - '2'
 libpng:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,20 +23,32 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_aarch64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            runs_on: ['ubuntu-24.04-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_ppc64le_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
     steps:
 
     - name: Checkout code
@@ -46,11 +58,13 @@ jobs:
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.CONDA_FORGE_DOCKER_RUN_ARGS }}"
+        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.docker_run_args }}"
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
@@ -70,6 +84,8 @@ jobs:
         else
           export IS_PR_BUILD="False"
         fi
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
@@ -77,6 +93,8 @@ jobs:
       id: build-macos
       if: matrix.os == 'macos'
       env:
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         CI: github_actions
@@ -95,6 +113,8 @@ jobs:
         else
           export IS_PR_BUILD="False"
         fi
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         ./.scripts/run_osx_build.sh
 
     - name: Build on windows
@@ -107,10 +127,8 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        # default value; make it explicit, as it needs to match with artefact
-        # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
-        MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -36,7 +36,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -11,6 +11,8 @@ source .scripts/logging_utils.sh
 
 set -xeo pipefail
 
+DOCKER_EXECUTABLE="${DOCKER_EXECUTABLE:-docker}"
+
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename "$THISDIR")"
 
@@ -27,7 +29,7 @@ if [[ "${sha:-}" == "" ]]; then
   popd
 fi
 
-docker info
+${DOCKER_EXECUTABLE} info
 
 # In order for the conda-build process in the container to write to the mounted
 # volumes, we need to run with the same id as the host machine, which is
@@ -35,6 +37,7 @@ docker info
 export HOST_USER_ID=$(id -u)
 # Check if docker-machine is being used (normally on OSX) and get the uid from
 # the VM
+
 if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
     export HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
 fi
@@ -76,16 +79,34 @@ if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
-( endgroup "Configure Docker" ) 2> /dev/null
+# Default volume suffix for Docker (preserve original behavior)
+VOLUME_SUFFIX=",z"
 
+# Podman-specific handling
+if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
+    # Fix file permissions for rootless podman builds
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${ARTIFACTS}"
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${RECIPE_ROOT}"
+
+    # Add SELinux label only if enforcing
+    if command -v getenforce &>/dev/null && [ "$(getenforce)" = "Enforcing" ]; then
+        VOLUME_SUFFIX=",z"
+    else
+        VOLUME_SUFFIX=""
+    fi
+fi
+
+( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 export IS_PR_BUILD="${IS_PR_BUILD:-False}"
-docker pull "${DOCKER_IMAGE}"
-docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
+
+${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
+
+${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,7 +26,7 @@ chmod +x "${micromamba_exe}"
 echo "Creating environment"
 "${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
   --channel conda-forge \
-  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
 echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
 mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
 echo "Cleaning up micromamba"
@@ -73,7 +73,7 @@ if [[ "${OSX_SDK_DIR:-}" == "" ]]; then
     /usr/bin/sudo chown "${USER}" "${OSX_SDK_DIR}"
   fi
 else
-  if tmpf=$(mktemp -p "$OSX_SDK_DIR" tmp.XXXXXXXX 2>/dev/null); then
+  if tmpf=$(mktemp "$OSX_SDK_DIR"/tmp.XXXXXXXX 2>/dev/null); then
       rm -f "$tmpf"
       echo "OSX_SDK_DIR is writeable without sudo, continuing"
   else

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -31,7 +31,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Creating environment
 call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefix "%MINIFORGE_HOME%" ^
     --channel conda-forge ^
-    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
 if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul

--- a/README.md
+++ b/README.md
@@ -45,7 +45,14 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>GitHub Actions</td>
+    <td>
+      <a href="https://github.com/conda-forge/freetype-feedstock/actions/workflows/conda-build.yml">
+        <img src="https://github.com/conda-forge/freetype-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
+      </a>
+    </td>
+  </tr>
     
   <tr>
     <td>Azure</td>
@@ -59,27 +66,6 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=331&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freetype-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_aarch64</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=331&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freetype-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_ppc64le</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=331&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freetype-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=331&branchName=main">
@@ -98,13 +84,6 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=331&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freetype-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>win_arm64</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=331&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/freetype-feedstock?branchName=main&jobName=win&configuration=win%20win_arm64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,5 @@
 build_platform:
-  linux_aarch64: linux_64
   linux_ppc64le: linux_64
-  osx_arm64: osx_64
   win_arm64: win_64
 conda_build:
   pkg_format: '2'
@@ -11,6 +9,5 @@ github:
   tooling_branch_name: main
 provider:
   linux_aarch64: default
-  linux_ppc64le: default
-  win: azure
+  osx_arm64: default
 test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,21 +55,24 @@ outputs:
         - {{ pin_subpackage('libfreetype' ~ so_name_major, exact=True) }}
     test:
       commands:
-        - ${PREFIX}/bin/freetype-config --version  # [not win]
-      # Need these things
-        - test -f ${PREFIX}/lib/libfreetype{{ SHLIB_EXT }}                       # [unix]
-        - test -f ${PREFIX}/lib/libfreetype.{{ so_name_major }}{{ SHLIB_EXT }}   # [osx]
-        - test -f ${PREFIX}/lib/libfreetype{{ SHLIB_EXT }}.{{ so_name_major }}   # [linux]
-        - test -f ${PREFIX}/lib/libfreetype{{ SHLIB_EXT }}.{{ so_name }}         # [linux]
-        - if not exist %PREFIX%\\Library\\lib\\freetype.lib exit 1               # [win]
-        - test -f ${PREFIX}/include/freetype2/freetype/freetype.h                # [unix]
-        - if not exist %PREFIX%\\Library\\include\\freetype\\freetype.h exit 1   # [win]
-        - test -f ${PREFIX}/lib/pkgconfig/freetype2.pc                            # [unix]
-        - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\freetype2.pc exit 1     # [win]
-        - if not exist %PREFIX%\\Library\\lib\\cmake\\freetype\\freetype-config.cmake exit 1     # [win]
-        - test -f ${PREFIX}/bin/freetype-config                               # [unix]
-      # Exclude these things
-        - test ! -f ${PREFIX}/lib/libfreetype.a                               # [unix]
+        # headers
+        - test -f ${PREFIX}/include/freetype2/freetype/freetype.h       # [unix]
+        - if not exist %LIBRARY_INC%\freetype\freetype.h exit 1         # [win]
+
+        # access to shared libraries (symlink resp. import lib; impl. is in libfreetype)
+        - test -f ${PREFIX}/lib/libfreetype{{ SHLIB_EXT }}              # [unix]
+        - if not exist %LIBRARY_LIB%\freetype.lib exit 1                # [win]
+
+        # absence of static libraries
+        - test ! -f ${PREFIX}/lib/libfreetype.a                         # [unix]
+
+        # binaries
+        - ${PREFIX}/bin/freetype-config --version                       # [unix]
+
+        # metadata
+        - test -f ${PREFIX}/lib/pkgconfig/freetype2.pc                  # [unix]
+        - if not exist %LIBRARY_LIB%\pkgconfig\freetype2.pc exit 1      # [win]
+        - if not exist %LIBRARY_LIB%\cmake\freetype\freetype-config.cmake exit 1  # [win]
 
   - name: libfreetype
     requirements:
@@ -106,7 +109,7 @@ outputs:
         - test -f ${PREFIX}/lib/libfreetype.{{ so_name_major }}{{ SHLIB_EXT }}   # [osx]
         - test -f ${PREFIX}/lib/libfreetype{{ SHLIB_EXT }}.{{ so_name_major }}   # [linux]
         - test -f ${PREFIX}/lib/libfreetype{{ SHLIB_EXT }}.{{ so_name }}         # [linux]
-        - if not exist %PREFIX%\\Library\\bin\\freetype.dll exit 1               # [win]
+        - if not exist %LIBRARY_BIN%\freetype.dll exit 1                         # [win]
     about:
       license: GPL-2.0-only OR FTL
       summary: The libfreetype runtime library.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: e61b31ab26358b946e767ed7eb7f4bb2e507da1cfefeb7a8861ace7fd5c899a1
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -53,7 +53,11 @@ outputs:
       run:
         - {{ pin_subpackage('libfreetype', exact=True) }}
         - {{ pin_subpackage('libfreetype' ~ so_name_major, exact=True) }}
+        # for pkg-config metadata
+        - zlib  # [win]
     test:
+      requires:
+        - pkg-config
       commands:
         # headers
         - test -f ${PREFIX}/include/freetype2/freetype/freetype.h       # [unix]
@@ -73,6 +77,9 @@ outputs:
         - test -f ${PREFIX}/lib/pkgconfig/freetype2.pc                  # [unix]
         - if not exist %LIBRARY_LIB%\pkgconfig\freetype2.pc exit 1      # [win]
         - if not exist %LIBRARY_LIB%\cmake\freetype\freetype-config.cmake exit 1  # [win]
+
+        # test pkg-config metadata is satisfied
+        - pkg-config --print-errors freetype2
 
   - name: libfreetype
     requirements:


### PR DESCRIPTION
Many projects are using freetype; for projects building through meson, the quality of the pkg-config metadata (i.e. whether it loads error-free) is a determinant whether the library can be used. Often, this means that meson will silently fall back to some vendored version, which is generally the opposite of what we want to achieve with our packaging. Add a test here that ensures the pkg-config metadata is complete/correct as installed.

This requires us to "bring along" more metadata packages (like `zlib` instead of `libzlib`; the former is where the pkg-config metadata is); the alternative would be to patch this out. In either case, the test is useful; otherwise we're just accumulating work-arounds like [this one](https://github.com/conda-forge/matplotlib-feedstock/blob/5fb967c298421aa1c06cedca940bd53b5fe7e423/recipe/meta.yaml#L53-L54).

Xref https://github.com/conda-forge/harfbuzz-feedstock/pull/162 & https://github.com/conda-forge/libraqm-feedstock/pull/3, so that https://github.com/conda-forge/matplotlib-feedstock/pull/439 works out of the box without matching all the accumulated parasitic pkg-config dependencies
